### PR TITLE
Improve performance in shine animation

### DIFF
--- a/src/animation/shine.js
+++ b/src/animation/shine.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 const START_VALUE = 0;
 const END_VALUE = 100;
 const DURATION = 750;
+const useNativeDriver = true;
 
 const styles = StyleSheet.create({
   shine: {
@@ -27,9 +28,12 @@ const Shine = ({ children }) => {
       Animated.timing(animation, {
         toValue: END_VALUE,
         duration: DURATION,
+        useNativeDriver,
       }),
-    ]).start(() => {
-      start();
+    ]).start((e) => {
+      if (e.finished) {
+        start();
+      }
     });
   }
 


### PR DESCRIPTION
Thank you for the amazing library!

While using `shine` animation we noticed it uses so much CPU power and leaks memory, and after changing to use `fade` animation that kind of thing never happens.

After comparing two animation logic we realized differences below:

- Activate useNativeDriver option
- Fix to start animation only when finished

So this PR addresses above two points. What do you think?

ref: https://github.com/mfrachet/rn-placeholder/pull/33