### PR TITLE
replace 'width:100%' with 'marginHorizontal'

### DIFF
--- a/src/line/line.js
+++ b/src/line/line.js
@@ -4,7 +4,6 @@ import { View } from "react-native";
 export const Line = ({
   textSize = 12,
   color = "#efefef",
-  useDefaultWidth,
   style,
   noMargin = false,
   ...props
@@ -14,14 +13,13 @@ export const Line = ({
   const backgroundColor = color;
   const borderRadius = textSize / 4;
   const marginBottom = noMargin ? 0 : textSize;
-  const lineWidth = useDefaultWidth ? { width: "100%" } : {};
   const computedStyle = {
     height,
     alignSelf,
     backgroundColor,
     borderRadius,
     marginBottom,
-    ...lineWidth
+    marginHorizontal: 0
   };
 
   return <View style={[computedStyle, style]} {...props} />;

--- a/src/line/line.js
+++ b/src/line/line.js
@@ -1,15 +1,15 @@
-import React from "react";
-import { View } from "react-native";
+import React from 'react';
+import { View } from 'react-native';
 
 export const Line = ({
   textSize = 12,
-  color = "#efefef",
+  color = '#efefef',
   style,
   noMargin = false,
   ...props
 }) => {
   const height = textSize;
-  const alignSelf = "stretch";
+  const alignSelf = 'stretch';
   const backgroundColor = color;
   const borderRadius = textSize / 4;
   const marginBottom = noMargin ? 0 : textSize;

--- a/src/line/line.js
+++ b/src/line/line.js
@@ -1,27 +1,27 @@
-import React from 'react';
-import { View } from 'react-native';
+import React from "react";
+import { View } from "react-native";
 
 export const Line = ({
   textSize = 12,
-  color = '#efefef',
-  width = '100%',
+  color = "#efefef",
+  width,
   style,
   noMargin = false,
   ...props
 }) => {
   const height = textSize;
-  const alignSelf = 'stretch';
+  const alignSelf = "stretch";
   const backgroundColor = color;
   const borderRadius = textSize / 4;
   const marginBottom = noMargin ? 0 : textSize;
-
+  const widthProp = width && { width };
   const computedStyle = {
     height,
     alignSelf,
     backgroundColor,
     borderRadius,
-    width,
     marginBottom,
+    ...widthProp
   };
 
   return <View style={[computedStyle, style]} {...props} />;

--- a/src/line/line.js
+++ b/src/line/line.js
@@ -4,7 +4,7 @@ import { View } from "react-native";
 export const Line = ({
   textSize = 12,
   color = "#efefef",
-  width,
+  useDefaultWidth,
   style,
   noMargin = false,
   ...props
@@ -14,14 +14,14 @@ export const Line = ({
   const backgroundColor = color;
   const borderRadius = textSize / 4;
   const marginBottom = noMargin ? 0 : textSize;
-  const widthProp = width && { width };
+  const lineWidth = useDefaultWidth ? { width: "100%" } : {};
   const computedStyle = {
     height,
     alignSelf,
     backgroundColor,
     borderRadius,
     marginBottom,
-    ...widthProp
+    ...lineWidth
   };
 
   return <View style={[computedStyle, style]} {...props} />;

--- a/src/placeholder/placeholder.js
+++ b/src/placeholder/placeholder.js
@@ -4,7 +4,6 @@ import Animations from "../animation/animations";
 
 const styles = StyleSheet.create({
   container: {
-    width: "100%",
     flexDirection: "row",
     flex: 1
   },
@@ -40,10 +39,10 @@ export const Placeholder = ({
   animation,
   customAnimation,
   children,
-  width,
   whenReadyRender: WhenReadyRender,
   renderLeft,
   renderRight,
+  useDefaultWidth = true,
   ...props
 }) => {
   const Root = customAnimation || makeRoot(animation);
@@ -54,9 +53,10 @@ export const Placeholder = ({
 
   const childrenArray = React.Children.toArray(children);
   const sizeOfChildren = childrenArray.length;
-  const containerWidth = (props && props.style && props.style.width) || "100%";
+  const containerWidth = useDefaultWidth ? { width: "100%" } : {};
+  const userStyle = props.style;
   return (
-    <Root style={[styles.container, width && { width }]} {...props}>
+    <Root {...props} style={[styles.container, userStyle, containerWidth]}>
       {renderLeft && withView(renderLeft, { style: styles.leftSide })}
       <View style={styles.centerElement}>
         {childrenArray.map((element, index) =>

--- a/src/placeholder/placeholder.js
+++ b/src/placeholder/placeholder.js
@@ -5,7 +5,8 @@ import Animations from "../animation/animations";
 const styles = StyleSheet.create({
   container: {
     flexDirection: "row",
-    flex: 1
+    flex: 1,
+    marginHorizontal: 0
   },
   centerElement: {
     flex: 1
@@ -42,7 +43,6 @@ export const Placeholder = ({
   whenReadyRender: WhenReadyRender,
   renderLeft,
   renderRight,
-  useDefaultWidth = true,
   ...props
 }) => {
   const Root = customAnimation || makeRoot(animation);
@@ -53,10 +53,9 @@ export const Placeholder = ({
 
   const childrenArray = React.Children.toArray(children);
   const sizeOfChildren = childrenArray.length;
-  const containerWidth = useDefaultWidth ? { width: "100%" } : {};
   const userStyle = props.style;
   return (
-    <Root {...props} style={[styles.container, userStyle, containerWidth]}>
+    <Root {...props} style={[styles.container, userStyle]}>
       {renderLeft && withView(renderLeft, { style: styles.leftSide })}
       <View style={styles.centerElement}>
         {childrenArray.map((element, index) =>

--- a/src/placeholder/placeholder.js
+++ b/src/placeholder/placeholder.js
@@ -1,25 +1,25 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
-import Animations from '../animation/animations';
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import Animations from "../animation/animations";
 
 const styles = StyleSheet.create({
   container: {
-    width: '100%',
-    flexDirection: 'row',
-    flex: 1,
+    width: "100%",
+    flexDirection: "row",
+    flex: 1
   },
   centerElement: {
-    flex: 1,
+    flex: 1
   },
   leftSide: {
-    marginRight: 12,
+    marginRight: 12
   },
   rightSide: {
-    marginLeft: 12,
-  },
+    marginLeft: 12
+  }
 });
 
-const makeRoot = (animation) => {
+const makeRoot = animation => {
   if (animation) {
     const Animation = Animations[animation];
 
@@ -40,6 +40,7 @@ export const Placeholder = ({
   animation,
   customAnimation,
   children,
+  width,
   whenReadyRender: WhenReadyRender,
   renderLeft,
   renderRight,
@@ -53,14 +54,16 @@ export const Placeholder = ({
 
   const childrenArray = React.Children.toArray(children);
   const sizeOfChildren = childrenArray.length;
-
+  const containerWidth = (props && props.style && props.style.width) || "100%";
   return (
-    <Root style={styles.container} {...props}>
+    <Root style={[styles.container, width && { width }]} {...props}>
       {renderLeft && withView(renderLeft, { style: styles.leftSide })}
       <View style={styles.centerElement}>
-        {childrenArray.map((element, index) => React.cloneElement(element, {
-          noMargin: index === sizeOfChildren - 1,
-        }))}
+        {childrenArray.map((element, index) =>
+          React.cloneElement(element, {
+            noMargin: index === sizeOfChildren - 1
+          })
+        )}
       </View>
       {renderRight && withView(renderRight, { style: styles.rightSide })}
     </Root>

--- a/src/placeholder/placeholder.js
+++ b/src/placeholder/placeholder.js
@@ -1,10 +1,10 @@
-import React from "react";
-import { View, StyleSheet } from "react-native";
-import Animations from "../animation/animations";
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Animations from '../animation/animations';
 
 const styles = StyleSheet.create({
   container: {
-    flexDirection: "row",
+    flexDirection: 'row',
     flex: 1,
     marginHorizontal: 0
   },


### PR DESCRIPTION
When I use Line and Placeholder components, I find they are hard to custom their width due to `width: 100%` limitation. Sometimes we just tell a component its marginHorizontal to calculate its width automatically. So I suggest replacing 'width: 100%' with 'marginHorizontal' to make styles more flexible.