### PR TITLE
fix: allow overriding Placeholder style

### DIFF
--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -24,7 +24,7 @@ export const Placeholder: React.FC<IPlaceholder> = ({
 
   return (
     <AnimationProvider>
-      <View style={[style, styles.row]} {...props}>
+      <View style={[styles.row, style]} {...props}>
         {Left && <Left style={styles.left} />}
         <View style={styles.full}>{children}</View>
         {Right && <Right style={styles.right} />}


### PR DESCRIPTION
Hi!

I was using this inside a `FlatList` with `numColums: 2`.

```js
<Placeholder Animation={Fade} style={{width: 'auto'}}}>
  <PlaceholderMedia
    style={{width, height}}
  />
</Placeholder>
```

Basically to override the `styles.row` from `Placeholder`, but:

```js
<View style={[style, styles.row]} {...props}>
```

This code does not let me override it even passing `style` because it should go at the end of the array. That's why this PR.

Thanks!