### PR TITLE
Add useNativeDriver to shine animations

### DIFF
--- a/src/animations/Shine.tsx
+++ b/src/animations/Shine.tsx
@@ -26,13 +26,16 @@ export class Shine extends React.Component<IShine> {
   public render() {
     const { children, style } = this.props;
 
-    const left = this.animation.interpolate({
+    const translateX = this.animation.interpolate({
       inputRange: [START_VALUE, END_VALUE],
-      outputRange: ["0%", "100%"],
+      outputRange: ["0%", "250%"],
+      extrapolateRight: "extend"
     });
 
     return (
-      <Provider value={[styles.shine, { left }, style]}>{children}</Provider>
+      <Provider value={[styles.shine, { transform: [{ translateX }] }, style]}>
+        {children}
+      </Provider>
     );
   }
 
@@ -43,8 +46,8 @@ export class Shine extends React.Component<IShine> {
       duration: this.props.duration || 750,
       isInteraction,
       toValue: END_VALUE,
-      useNativeDriver: false,
-    }).start((e) => {
+      useNativeDriver: true
+    }).start(e => {
       if (e.finished) {
         this.start();
       }
@@ -57,6 +60,6 @@ const styles = StyleSheet.create({
     backgroundColor: "white",
     height: "100%",
     opacity: 0.5,
-    width: "40%",
-  },
+    width: "40%"
+  }
 });

--- a/src/animations/ShineOverlay.tsx
+++ b/src/animations/ShineOverlay.tsx
@@ -10,10 +10,14 @@ export interface IShine {
   duration?: number;
 }
 
-export class ShineOverlay extends React.Component<IShine> {
+export class ShineOverlay extends React.Component<IShine, { width: number }> {
   private animation: Animated.Value;
   constructor(props: IShine) {
     super(props);
+
+    this.state = {
+      width: 0
+    };
 
     this.animation = new Animated.Value(0);
   }
@@ -25,15 +29,19 @@ export class ShineOverlay extends React.Component<IShine> {
   public render() {
     const { children } = this.props;
 
-    const left = this.animation.interpolate({
+    const translateX = this.animation.interpolate({
       inputRange: [START_VALUE, END_VALUE],
-      outputRange: ["0%", "100%"],
+      outputRange: [0, this.state.width]
     });
 
     return (
-      <View>
+      <View
+        onLayout={e => this.setState({ width: e.nativeEvent.layout.width })}
+      >
         {children}
-        <Animated.View style={[styles.shine, { left }]} />
+        <Animated.View
+          style={[styles.shine, { transform: [{ translateX }] }]}
+        />
       </View>
     );
   }
@@ -45,8 +53,8 @@ export class ShineOverlay extends React.Component<IShine> {
       duration: this.props.duration || 750,
       isInteraction,
       toValue: END_VALUE,
-      useNativeDriver: false,
-    }).start((e) => {
+      useNativeDriver: true
+    }).start(e => {
       if (e.finished) {
         this.start();
       }
@@ -60,6 +68,6 @@ const styles = StyleSheet.create({
     height: "100%",
     opacity: 0.4,
     position: "absolute",
-    width: 30,
-  },
+    width: 30
+  }
 });


### PR DESCRIPTION
Make `Shine` and `ShineOverlay` animations run on the native thread. Related to this issue: https://github.com/mfrachet/rn-placeholder/issues/99 

Only remaining animation on the JS side is `Progressive`. 
I think this is still possible but I would want to start a discussion regarding this. For using `translateX` as the animated prop you need the width of how much to translate. 

My attempts at converting `Progressive` were making the animation look different from the initial one because the `Progressive` View was the same width on all children (Left, Right or Other Media) therefore translating with `50%` would look different on lines of different length and it was not possible to find the width of the `PlaceHolderLine` or `Media` to translate only by that, as the Animation Consumer was put inside the View and not on the outside. 

Example
![IMG_1835](https://user-images.githubusercontent.com/16940343/93016405-9aa5a500-f5c9-11ea-8d1f-b0b3c83d1e64.png)

In the picture above, I translated the `AnimatedView` with `-20%`, as you can see, in the Left and Right media, this shows a progress of `50%` because the View is translated by `20%` of its own width. 

A possible solution would be to define the `AnimationConsumer` inside the `PlaceholderLine` and `PlaceholderMedia` so that you can pass through that context an `onLayout` function that can get the width of the parent. 

I considered that to be a bit too much of a reimplementation, but that would solve the problem. If you give the alright for that, I would provide a different PR with this. 

Until then, here is `Shine` and `ShineOverlay` 😄  
